### PR TITLE
F3 Screen fixes and optimizations

### DIFF
--- a/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
+++ b/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
@@ -49,10 +49,10 @@ public abstract class DebugScreenOverlayM {
         long totalMemory = Runtime.getRuntime().totalMemory();
         long usedMemory = totalMemory - Runtime.getRuntime().freeMemory();
 
-        strings.add(format("Java: {0} {1}-bit", System.getProperty("java.version"), this.minecraft.is64Bit() ? "64" : "32"));
-        strings.add(format("Mem: {0}% {1}/{2}MB", (usedMemory * 100L / maxMemory), bytesToMegabytes(usedMemory), bytesToMegabytes(maxMemory)));
-        strings.add(format("Allocated: {0}% {1}MB", (totalMemory * 100L / maxMemory), bytesToMegabytes(totalMemory)));
-        strings.add(format("Off-heap: {0}MB", bytesToMegabytes(ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getUsed())));
+        strings.add(fastFormat("Java: {0} {1}-bit", System.getProperty("java.version"), this.minecraft.is64Bit() ? 64 : 32));
+        strings.add(fastFormat("Mem: {0}% {1}/{2}MB", (usedMemory * 100L / maxMemory), bytesToMegabytes(usedMemory), bytesToMegabytes(maxMemory)));
+        strings.add(fastFormat("Allocated: {0}% {1}MB", (totalMemory * 100L / maxMemory), bytesToMegabytes(totalMemory)));
+        strings.add(fastFormat("Off-heap: {0}MB", bytesToMegabytes(ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getUsed())));
         strings.add("");
         strings.add("VulkanMod v" + getVersion());
         strings.add("CPU: " + SystemInfo.cpuInfo);
@@ -63,8 +63,8 @@ public abstract class DebugScreenOverlayM {
         strings.add("Driver Version:" + device.driverVersion);
         strings.add("Vulkan Version:" + device.vkVersion);
         strings.add("");
-        strings.add(format("GPUMemory: {0}MB", MemoryManager.getInstance().getAllocatedDeviceMemoryMB()));
-        strings.add(format("NativeMemory: {0}MB", MemoryManager.getInstance().getNativeMemoryMB()));
+        strings.add(fastFormat("GPUMemory: {0}MB", MemoryManager.getInstance().getAllocatedDeviceMemoryMB()));
+        strings.add(fastFormat("NativeMemory: {0}MB", MemoryManager.getInstance().getNativeMemoryMB()));
         strings.add("");
         strings.add("");
 
@@ -84,7 +84,7 @@ public abstract class DebugScreenOverlayM {
         return bytes >> 20;
     }
 
-    private final String format(String format, Object... args) {
+    private final String fastFormat(String format, Object... args) {
         return MessageFormatter.arrayFormat(format, args).getMessage();
     }
 

--- a/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
+++ b/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
@@ -54,18 +54,22 @@ public abstract class DebugScreenOverlayM {
 
         Device device = Vulkan.getDevice();
 
-        strings.add(String.format("Java: %s %dbit", System.getProperty("java.version"), this.minecraft.is64Bit() ? 64 : 32));
-        strings.add(String.format("Mem: % 2d%% %03d/%03dMB", usedMemory * 100L / maxMemory, bytesToMegabytes(usedMemory), bytesToMegabytes(maxMemory)));
-        strings.add(String.format("Allocated: % 2d%% %03dMB", totalMemory * 100L / maxMemory, bytesToMegabytes(totalMemory)));
-        strings.add(String.format("Off-heap: " + getOffHeapMemory() + "MB"));
+        strings.add("Java: %s %dbit".formatted(System.getProperty("java.version"), this.minecraft.is64Bit() ? 64 : 32));
+        strings.add("Mem: % 2d%% %03d/%03dMB".formatted(usedMemory * 100L / maxMemory, bytesToMegabytes(usedMemory), bytesToMegabytes(maxMemory)));
+        strings.add("Allocated: % 2d%% %03dMB".formatted(totalMemory * 100L / maxMemory, bytesToMegabytes(totalMemory)));
+        strings.add("Off-heap: " + getOffHeapMemory() + "MB");
+        strings.add("");
+        strings.add("VulkanMod v" + getVersion());
+        strings.add("CPU: " + SystemInfo.cpuInfo);
+        strings.add("");
+        strings.add("GPU Properties:");
+        strings.add("Name: " + device.deviceName);
+        strings.add("Driver: " + device.driverName);
+        strings.add("Driver Version:" + device.driverVersion);
+        strings.add("Vulkan Version:" device.vkVersion);
+        strings.add("");
         strings.add("NativeMemory: %dMB".formatted(MemoryManager.getInstance().getNativeMemoryMB()));
         strings.add("DeviceMemory: %dMB".formatted(MemoryManager.getInstance().getAllocatedDeviceMemoryMB()));
-        strings.add("");
-        strings.add("VulkanMod " + getVersion());
-        strings.add("CPU: " + SystemInfo.cpuInfo);
-        strings.add("GPU: " + device.deviceName);
-        strings.add("Driver: " + device.driverVersion);
-        strings.add("Vulkan: " + device.vkVersion);
         strings.add("");
         strings.add("");
 

--- a/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
+++ b/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
@@ -49,10 +49,10 @@ public abstract class DebugScreenOverlayM {
         long totalMemory = Runtime.getRuntime().totalMemory();
         long usedMemory = totalMemory - Runtime.getRuntime().freeMemory();
 
-        strings.add(fastFormat("Java: {0} {1}-bit", System.getProperty("java.version"), this.minecraft.is64Bit() ? 64 : 32));
-        strings.add(fastFormat("Mem: {0}% {1}/{2}MB", (usedMemory * 100L / maxMemory), bytesToMegabytes(usedMemory), bytesToMegabytes(maxMemory)));
-        strings.add(fastFormat("Allocated: {0}% {1}MB", (totalMemory * 100L / maxMemory), bytesToMegabytes(totalMemory)));
-        strings.add(fastFormat("Off-heap: {0}MB", bytesToMegabytes(ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getUsed())));
+        strings.add(fastFormat("Java: {} {}-bit", System.getProperty("java.version"), this.minecraft.is64Bit() ? 64 : 32));
+        strings.add(fastFormat("Mem: {}% {}/{}MB", (usedMemory * 100L / maxMemory), bytesToMegabytes(usedMemory), bytesToMegabytes(maxMemory)));
+        strings.add(fastFormat("Allocated: {}% {}MB", (totalMemory * 100L / maxMemory), bytesToMegabytes(totalMemory)));
+        strings.add(fastFormat("Off-heap: {}MB", bytesToMegabytes(ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getUsed())));
         strings.add("");
         strings.add("VulkanMod v" + getVersion());
         strings.add("CPU: " + SystemInfo.cpuInfo);
@@ -60,11 +60,11 @@ public abstract class DebugScreenOverlayM {
         strings.add("GPU Properties:");
         strings.add("Name: " + device.deviceName);
         strings.add("Driver: " + device.driverName);
-        strings.add("Driver Version:" + device.driverVersion);
-        strings.add("Vulkan Version:" + device.vkVersion);
+        strings.add("Driver Version: " + device.driverVersion);
+        strings.add("Vulkan Version: " + device.vkVersion);
         strings.add("");
-        strings.add(fastFormat("GPUMemory: {0}MB", MemoryManager.getInstance().getAllocatedDeviceMemoryMB()));
-        strings.add(fastFormat("NativeMemory: {0}MB", MemoryManager.getInstance().getNativeMemoryMB()));
+        strings.add(fastFormat("GPUMemory: {}MB", MemoryManager.getInstance().getAllocatedDeviceMemoryMB()));
+        strings.add(fastFormat("NativeMemory: {}MB", MemoryManager.getInstance().getNativeMemoryMB()));
         strings.add("");
         strings.add("");
 

--- a/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
+++ b/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
@@ -8,8 +8,10 @@ import net.vulkanmod.vulkan.SystemInfo;
 import net.vulkanmod.vulkan.Vulkan;
 import net.vulkanmod.vulkan.device.Device;
 import net.vulkanmod.vulkan.memory.MemoryManager;
+import org.slf4j.helpers.MessageFormatter;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -18,8 +20,6 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import org.slf4j.helpers.MessageFormatter;
 
 import static net.vulkanmod.Initializer.getVersion;
 

--- a/src/main/java/net/vulkanmod/vulkan/device/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/device/Device.java
@@ -1,11 +1,7 @@
 package net.vulkanmod.vulkan.device;
 
-import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.vulkan.*;
-import oshi.SystemInfo;
-import oshi.hardware.CentralProcessor;
-
 import java.nio.IntBuffer;
 import java.util.HashSet;
 import java.util.Set;
@@ -14,9 +10,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM_WIN32;
 import static org.lwjgl.glfw.GLFW.glfwGetPlatform;
 import static org.lwjgl.system.MemoryStack.stackPush;
-import static org.lwjgl.vulkan.VK10.*;
-import static org.lwjgl.vulkan.VK11.vkEnumerateInstanceVersion;
-import static org.lwjgl.vulkan.VK11.vkGetPhysicalDeviceFeatures2;
+import static org.lwjgl.vulkan.VK11.*;
 
 public class Device {
     final VkPhysicalDevice physicalDevice;
@@ -25,6 +19,7 @@ public class Device {
     private final int vendorId;
     public final String vendorIdString;
     public final String deviceName;
+    public final String driverName;
     public final String driverVersion;
     public final String vkVersion;
 
@@ -42,9 +37,19 @@ public class Device {
         properties = VkPhysicalDeviceProperties.malloc();
         vkGetPhysicalDeviceProperties(physicalDevice, properties);
 
+        VkPhysicalDeviceProperties2 properties2 = VkPhysicalDeviceProperties2.malloc(stack);
+        properties2.sType$Default();
+
+        VkPhysicalDeviceDriverProperties driverProperties = VkPhysicalDeviceDriverProperties.malloc(stack);
+        driverProperties.sType$Default();
+        properties2.pNext(driverProperties);
+
+        vkGetPhysicalDeviceProperties2(physicalDevice, properties2);
+
         this.vendorId = properties.vendorID();
         this.vendorIdString = decodeVendor(properties.vendorID());
         this.deviceName = properties.deviceNameString();
+        this.driverName = driverProperties.driverNameString();
         this.driverVersion = decodeDvrVersion(properties.driverVersion(), properties.vendorID());
         this.vkVersion = decDefVersion(properties.apiVersion());
 

--- a/src/main/java/net/vulkanmod/vulkan/device/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/device/Device.java
@@ -37,10 +37,10 @@ public class Device {
         properties = VkPhysicalDeviceProperties.malloc();
         vkGetPhysicalDeviceProperties(physicalDevice, properties);
 
-        VkPhysicalDeviceProperties2 properties2 = VkPhysicalDeviceProperties2.malloc(stack);
+        VkPhysicalDeviceProperties2 properties2 = VkPhysicalDeviceProperties2.malloc();
         properties2.sType$Default();
 
-        VkPhysicalDeviceDriverProperties driverProperties = VkPhysicalDeviceDriverProperties.malloc(stack);
+        VkPhysicalDeviceDriverProperties driverProperties = VkPhysicalDeviceDriverProperties.malloc();
         driverProperties.sType$Default();
         properties2.pNext(driverProperties);
 

--- a/src/main/java/net/vulkanmod/vulkan/device/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/device/Device.java
@@ -37,19 +37,22 @@ public class Device {
         properties = VkPhysicalDeviceProperties.malloc();
         vkGetPhysicalDeviceProperties(physicalDevice, properties);
 
-        VkPhysicalDeviceProperties2 properties2 = VkPhysicalDeviceProperties2.malloc();
+        try (MemoryStack stack = stackPush()) {
+        VkPhysicalDeviceProperties2 properties2 = VkPhysicalDeviceProperties2.malloc(stack);
         properties2.sType$Default();
 
-        VkPhysicalDeviceDriverProperties driverProperties = VkPhysicalDeviceDriverProperties.malloc();
+        VkPhysicalDeviceDriverProperties driverProperties = VkPhysicalDeviceDriverProperties.malloc(stack);
         driverProperties.sType$Default();
         properties2.pNext(driverProperties);
 
         vkGetPhysicalDeviceProperties2(physicalDevice, properties2);
 
+        this.driverName = driverProperties.driverInfoString();
+        }
+
         this.vendorId = properties.vendorID();
         this.vendorIdString = decodeVendor(properties.vendorID());
         this.deviceName = properties.deviceNameString();
-        this.driverName = driverProperties.driverInfoString();
         this.driverVersion = decodeDvrVersion(properties.driverVersion(), properties.vendorID());
         this.vkVersion = decDefVersion(properties.apiVersion());
 

--- a/src/main/java/net/vulkanmod/vulkan/device/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/device/Device.java
@@ -38,16 +38,16 @@ public class Device {
         vkGetPhysicalDeviceProperties(physicalDevice, properties);
 
         try (MemoryStack stack = stackPush()) {
-        VkPhysicalDeviceProperties2 properties2 = VkPhysicalDeviceProperties2.malloc(stack);
-        properties2.sType$Default();
+            VkPhysicalDeviceProperties2 properties2 = VkPhysicalDeviceProperties2.malloc(stack);
+            properties2.sType$Default();
 
-        VkPhysicalDeviceDriverProperties driverProperties = VkPhysicalDeviceDriverProperties.malloc(stack);
-        driverProperties.sType$Default();
-        properties2.pNext(driverProperties);
+            VkPhysicalDeviceDriverProperties driverProperties = VkPhysicalDeviceDriverProperties.malloc(stack);
+            driverProperties.sType$Default();
+            properties2.pNext(driverProperties);
 
-        vkGetPhysicalDeviceProperties2(physicalDevice, properties2);
+            vkGetPhysicalDeviceProperties2(physicalDevice, properties2);
 
-        this.driverName = driverProperties.driverInfoString();
+            this.driverName = driverProperties.driverInfoString();
         }
 
         this.vendorId = properties.vendorID();

--- a/src/main/java/net/vulkanmod/vulkan/device/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/device/Device.java
@@ -49,7 +49,7 @@ public class Device {
         this.vendorId = properties.vendorID();
         this.vendorIdString = decodeVendor(properties.vendorID());
         this.deviceName = properties.deviceNameString();
-        this.driverName = driverProperties.driverNameString();
+        this.driverName = driverProperties.driverInfoString();
         this.driverVersion = decodeDvrVersion(properties.driverVersion(), properties.vendorID());
         this.vkVersion = decDefVersion(properties.apiVersion());
 


### PR DESCRIPTION
+ Add the GPU driver name to the F3 screen
+ Replaced `String.formatted` to SLF4J's `MessageFormatter` for faster formatting
+ Overwrite `bytesToMegabytes` and use bit
-shift operation instead of division for faster conversion